### PR TITLE
🔗 fix broken links on docs/astro-integration  

### DIFF
--- a/src/content/docs/astro-integration/guides/edge-kv.md
+++ b/src/content/docs/astro-integration/guides/edge-kv.md
@@ -1,0 +1,65 @@
+---
+title: "Edge KV"
+description: Configuring Cloudflare edge kv.
+---
+
+Altitude KV Stores can be used as a store for tenant configuration, which can be read at request time. Edge Key-Value stores (KVs) enable fast, scalable, distributed data storage at network edges, reducing latency for global applications.
+
+To configure your Altitude KV store with Astro create a [middleware](https://docs.astro.build/en/guides/middleware/). Utilising the `getRuntime` provided in `@astrojs/cloudflare/runtime` method you can perform a lookup for KV.
+
+```javascript
+// middleware/index.js
+import { getRuntime } from "@astrojs/cloudflare/runtime";
+
+export async function onRequest(context, next) {
+  const { env } = getRuntime(request);
+
+  const tenantConfig = await env.ALTITUDE_KV_STORE.get("<kv-name>", {
+    type: "json",
+  });
+
+  context.locals.tenantConfig = tenantConfig;
+
+  return next();
+}
+```
+
+Ensure that you replace `<kv-name>` with the name of your KV listed in Altitude Platform. More details on creating a KV store using Altitude [here](https://docs.thgaltitude.com/edge/kv-store/).
+
+The following line will adds the KV store to the Astro Context object to make it available to read in any page.
+
+```js
+context.locals.tenantConfig = tenantConfig;
+```
+
+Example use:
+
+```js
+//page/index.astro
+---
+const { tenantConfig } = Astro.locals
+---
+
+{ tenantConfig.exampleFeatureFlag && <h1>Feature Enabled</h1> }
+```
+
+:::caution
+The runtime used for reading KV will only be accessible after deploying the website. Ensure you have a local JSON equivelant for local development in place of the runtime.
+:::
+
+## Framework Guides
+
+- [Astro: Edge KV](/frameworks/astro/#edge-kvs)
+
+## Astro Integration
+
+Users of the integration will no longer have to bind KV's within their own middleware at runtime. The integration will handle the binding of KVs inside of entry middleware and attach the value(s) to the [altitude global context](/packages/astro-integration/#altitude-global-context). More information about the KV schema can be found [here](/packages/astro-integration/#kv).
+
+Multiple KV's can be provided for an application/site, the integration will iterate over each entry and attach the value to the corresponding namespace. Applications can rebind KVs to a preferred key if required within their middleware as shown below.
+
+```js
+//middleware/index.js
+context.locals.tenantConfig = context.locals.altitude.runtime.kv.<namespace>
+```
+
+For environments that are not running within a Cloudflare worker, a local copy of the KV should be supplied and will be used attaching it to the same `namespace` provided.

--- a/src/content/docs/astro-integration/guides/i18n.md
+++ b/src/content/docs/astro-integration/guides/i18n.md
@@ -1,0 +1,286 @@
+---
+title: "Internationalisation"
+description: Coming soon.
+sidebar:
+  badge:
+    text: Alpha
+    variant: tip
+---
+
+# Internationalisation
+
+If you're looking to translate your website to multiple languages, there are a number of factors to consider.
+
+1. **Language Dictionary** - The collection of language strings. Typically in JSON format.
+2. **Routing by Language** - Path based rules that dictate which language dictionary and configuration to load.
+3. **API Localisation** - A route to request translated data from the API.
+4. **Domains** - How to associate a domian to a specific locale.
+5. **Previewing Language Strings** - How to preview the object structure that represent a particular string on a website. Used to support non-technical stakeholders with understanding what keys to update.
+
+In this guide we will go through how to achieve each of these steps.
+
+## Language Dictionaries
+
+### Ingenuity Properties and Edge KV (Recommended)
+
+Using Ingenuity's Properties Service for managing your language dictionary is recommended as this allows non-technical users to manage the language used across the website without a deployment.
+
+Ingenuity Properties Service is a UI for managing your language dictionary. It's a list of keys and values.
+
+For the purpose of this guide we assume you have access to our Ingenuity Service's. If you do not, you can request access from your Ingenuity Project team.
+
+#### Adding Properties
+
+For Altitude deployed sites we syncronise the values in the Ingenuity Properties Service to a key-value store that lives with your deployed website. Typically referred to as an Edge KV.
+
+This allows for high-performance read operations and for the site to update language entries without requiring a deployment.
+
+We will sync any values from Properties Service that begin following the following format:
+`altitude.<anystring>`
+
+#### Linking Properties Service to your KV
+
+:::note
+This is currently not yet available to all customers. Please contact the Altitude Platform team to enable this feature.
+:::
+
+#### Reading Properties
+
+Once you have linked Properties Service to your KV you can begin to read the KV from your codebase. Refer to the framework guides below on how to read from a KV.
+
+If you're utilising our integrations there are helper methods available for i18n. Refer to the guides referenced below.
+
+##### Framework Guides
+
+- [Astro: Reading from Edge KVs in Astro](/guides/edge-kv/)
+- [Astro Integration: Edge KV configuration](/packages/astro-integration/#kv)
+- [Astro Integration: i18n method](/packages/astro-integration/#i18n)
+
+### Local Dictionary
+
+You can establish a local language dictionary in the codebase by creating local JSON files. For ease of access you can apply these in a middleware to make them accessible across your application.
+
+If you are using the Astro Integration, a local copy of your language dictionary can alternatively be supplied as part of the configuration setup for KV. This enables local environments to read directly from a local JSON file at runtime. [See more](/packages/astro-integration/#kv)
+
+## Astro Integration
+
+Users of the integration have the ability to opt in to i18n to unlock localisation on their application. The integration is responsible for mapping to locale specific configs and validating a locale is supported when a request is made.
+
+To opt in to this behaviour additional config must be provided to the [configuration](/packages/astro-integration/#configuration) of a site.
+
+### i18n.fallbackLocale
+
+**Type**: `String` \
+ **Required: True**
+
+The fallback locale if the locale of the request is invalid.
+
+```javascript
+i18n: {
+  fallbackLocale: "en-gb";
+}
+```
+
+### i18n.exclusionList
+
+**Type**: `Array[]` \
+**Required: False**
+
+An array containing the prefix of the path that should not be localised and subject to localisation at runtime i.e proxies
+
+```javascript
+i18n: {
+  exclusionList: ["account", "images"];
+}
+```
+
+### i18n.localeCookie
+
+**Type**: `String` \
+**Required: False** \
+**Fallback**: `locale_V6`
+
+The name of the cookie that the locale will be stored in. This is also used to determine a users preferred locale from previous sessions and exposed on the [altitude global context](/packages/astro-integration/#altitude-global-context). If no value has been supplied, the integration will attempt to look for a cookie named `locale_V6`. If the integration is unable to resolve a value from the cookie or the locale is not supported, `Accept-Language` headers from the request will attempted to be used and exposed, otherwise the preferred locale will be `null`.
+
+```javascript
+i18n: {
+  localeCookie: "site_locale";
+}
+```
+
+### i18n.locales
+
+**Type**: `Array[]` \
+**Required: True**
+
+An array of locale configs can be supplied. Below are the options that should be supplied per entry.
+
+```javascript
+i18n: {
+  locales: [
+    {
+      // en-gb setup
+    },
+    {
+      // fr-fr setup
+    },
+  ];
+}
+```
+#### Locale Inheritance
+Locale configs are treated in a special way in the Astro integration and will inherit from the main config file e.g. this config
+```javascript
+{
+  domains: {
+    default: 'www.acme.com',
+    variants: ['www.acme.com']
+  },
+  commerce: {
+    endpoint: 'https://www.acme.com'
+  },
+  i18n: {
+    locales: [
+      {
+        prefix: 'en-gb',
+        domain: 'www.acme.com',
+        kv: [
+          {
+            key: 'acme',
+            namespace: 'config'
+          }
+        ]
+      }
+    ],
+    fallbackLocale: 'en-gb'
+  }
+}
+```
+Will be treated like the below config by the integration.
+```javascript
+{
+  domains: {
+    default: 'www.acme.com',
+    variants: ['www.acme.com']
+  },
+  commerce: {
+    endpoint: 'https://www.acme.com'
+  },
+  i18n: {
+    locales: [
+      {
+        prefix: 'en-gb',
+        domain: 'www.acme.com',
+        kv: [
+          {
+            key: 'acme',
+            namespace: 'config'
+          }
+        ],
+        domains: {
+          default: 'www.acme.com',
+          variants: ['www.acme.com']
+        },
+        commerce: {
+          endpoint: 'https://www.acme.com'
+        }
+      }
+    ],
+    fallbackLocale: 'en-gb'
+  }
+}
+```
+Notice how the `domains` and `commerce` objects from the top level config are copied into the locale specific config. If a key is present in the locale specific it will **always** take precedence over the same key in the main config and thus act as an override. This inheritance and override behaviour is then applied to nested fields in the main and locale configs. However it does **not** apply to array elements, arrays are inherited or overidden in their entirety. If you want to explicitly opt out of inheriting a particular key from the main config then set that key or its parent as `null` in the locale config.
+### i18n.locales.\<Object>.prefix
+
+**Type**: `String` \
+**Required: True**
+
+The locale this config is associated with.
+
+```javascript
+locales: [
+  {
+    prefix: "en-gb",
+  },
+];
+```
+
+### i18n.locales.\<Object>.domain
+
+**Type**: `String` \
+**Required: False**
+
+The [global top level domain](/#localised-domains)(gTLDs) of this locale excluding protocol. The domain must be specified in the [variants](/packages/astro-integration/#domains-options) key of the `domains` object at the root of the config to ensure the integration can map to the sites config.
+
+:::note
+(Coming soon)
+The absence of this key will resolve to request to prepend the locale on the path of the `default` domain.
+:::
+
+```javascript
+locales: [
+  {
+    prefix: "en-gb",
+    domain: "www.example.com",
+  },
+  {
+    prefix: "fr-fr",
+    domain: "www.example.fr",
+  },
+];
+```
+
+### i18n.locales.\<Object>.kv
+
+Any locale specific KV keys to be retrieved from the cloudflare namespace. See config setup [here](/packages/astro-integration/#kv).
+
+If there are no locale specific KV settings then favour putting them in the top-level kv object instead.
+
+### i18n.locales.\<Object>.commerce.endpoint
+
+Any locale specific api endpoint to be used. See config setup [here](/packages/astro-integration/#commerce)
+
+### Custom
+
+Custom keys can also be supplied to the build config at locale level as well. [See more](/packages/astro-integration/#custom)
+
+## Routing by Language
+
+:::note
+Guide coming soon
+:::
+
+## Localised Domains
+
+Global top level domains or gTLDs provide SEO benefits by providing localised content on a separate domain. The integration provides application owners the flexibility to configure whether valid locales should redirect to an associated gTLD.
+
+To enable localised domains, a locale should supply a `domain` within its respective locale config file. The integration will rewrite the underlying request to prefix the locale to the request which will resolve to the specific config file the locale and gTLD of the request is associated with. This domain should also be added to the `domains.variants` array within the sites config file.
+
+To mitigate the risk of duplicate content, any requests directly to the prefix that have not been subject to a rewrite will 404.
+
+Example request pattern:
+
+```text
+www.example.com => rewrite => www.example.com/en-gb/
+www.example.com/en-gb/ => www.example.com/en-gb/ (404)
+```
+
+### Application setup
+
+As well as configuration updates, application owners must amend routing logic within their application. Routes within the application should be nested inside of a [dynamic route](https://docs.astro.build/en/guides/routing/) unless specified in the `exclusionList` as outlined in the above configuration. The param to use for this dynamic route **must be** `locale`.
+
+Further to this, to handle invalid locales as part of the request, an additional catch all page should be created at the root of the pages directory to force [on demand rendering](https://docs.astro.build/en/guides/server-side-rendering/#return-a-response-object). If your application already contains a catch all route, this should be moved inside of the dynamic `[locale]` route and the following snippet added to the new catch all route.
+
+```javascript
+//pages/[...https].astro
+// new catch all page
+---
+return new Response(null, Astro.response)
+---
+```
+
+The 404.astro page should remain at the **root** of the pages directory to serve any custom 404 pages.
+
+## API Localisation
+
+When switching the language of a site either through path based routing or gTLDs (Global top level domains) it might be desired that the copy and content/products on site also change if they are independently traded. The integration is able to seamlessly achieve API switching by enabling applications to configure custom configs per locale for sites, including defining different API endpoints. This value should be supplied in the `i18n.locales` locale specific config.

--- a/src/content/docs/astro-integration/guides/multitenancy.md
+++ b/src/content/docs/astro-integration/guides/multitenancy.md
@@ -1,0 +1,147 @@
+---
+title: "Multi-Tenancy"
+description: Serve multiple brands from a single Altitude site.
+---
+
+Multi-tenancy is a pattern in which multiple brands may be served from the same codebase. It can be used to quickly onboard a new brand, or 'tenant', via a new configuration, as a fast route to scale.
+
+---
+
+## Custom Domains
+
+Altitude allows multiple [custom domains](https://docs.thgaltitude.com/edge/domains/) to be attached to a single site, giving the feel of a separately hosted site per-tenant.
+
+For example `www.allsole.com` and `www.biossance.com` point to the same Altitude deployment.
+
+## Tenant Configuration
+
+There are certain properties which will want to vary between tenants to give then a distinct feel, such as:
+
+- Styling
+- Feature flags
+- API urls, reCaptcha keys etc.
+
+A solution to achieving this is for your application to read these properties from a configuration object which can vary per-tenant.
+
+## Key-Value Stores
+
+Altitude KV Stores can be used as a store for tenant configuration, which can be read at request time.
+
+If your application is using the [Astro integration package](/packages/astro-integration/) the KV binding will occur at runtime from within the integration otherwise refer to your appropriate framework guide on how to set this up.
+
+#### Framework Guides
+
+- [Astro: Edge KV](/frameworks/astro/#edge-kvs)
+
+## Determining the Tenant
+
+In order to read the correct tenant config in middleware, the tenant for the incoming request first needs to be determined.
+
+### Production Environments
+
+A mapping between custom domain and tenant config key can be used to determine the correct key per request. Production environments can use `X-Forwarded-Host` which will be provided as a request header from Fastly.
+
+### Local and UAT Environments
+
+For cases where custom domains are not attached, such as `localhost` and on deployments to other Altitude development environments, a custom HTTP header may be used to specify tenant per request. A browser extension such as [ModHeader](https://modheader.com/) is convenient for fast tenant switching in this case.
+
+## Multi-tenancy Stylesheets
+
+When sharing a codebase with multiple tenants, being able to still differentiate branding colours and typography is essential. However it's equally essential to ensure that the codebase is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and you're not building stylesheets when not necessary.
+
+### Tailwind
+
+By utilising [Tailwind Themes](https://tailwindcss.com/docs/theme) alongside a combination of data attributes and CSS variables you can achieve a pattern of having one shared UI but with tenant specific CSS.
+
+Example:
+
+```css
+//main.css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html[data-theme="default"] {
+    --color-esther: 34, 39, 46;
+    --color-maximus: 45, 51, 59;
+    --color-linx: 55, 62, 71;
+  }
+
+  html[data-theme="neon"] {
+    --color-esther: 20, 61, 42;
+    --color-maximus: 13, 82, 66;
+    --color-linx: 20, 82, 11;
+  }
+}
+```
+
+Within your HTML you then switch to the relevant theme:
+
+```html
+<html data-theme="neon"></html>
+```
+
+##### Alternative: DaisyUI + Tailwind
+
+DaisyUI offers a multi-theme configuration out of the box. This can help achieve the capability of creating multiple themes which can be used for creating variety across tenants.
+
+[DaisyUI Themes](https://daisyui.com/docs/themes/)
+[DaisyUI components](https://daisyui.com/components/)
+
+:::note
+Tailwind is a build time dependency and is unaware at the build stage what tenant is active. Therefore you need to consider that the impact of not optimising your theme file(s) efficiently so that minimal CSS changes are required will result in all tenants CSS weight increasing.
+
+Using this alongside a speific tenant CSS file that is loaded at runtime (for minor layout changes / adjustments) will help the CSS scale to a larger volume of sites without concerns of shared performance regressions.
+:::
+
+### Astro Integration
+
+Applications using the Astro Integration can leverage built in mapping to resolve configs to the correct tenant. This is determined at runtime and domains (x-altitude-instance for local development or the domain in prod) will be mapped by matching a value from within a tenants [`domains.variants`](/packages/astro-integration/#domains-options) array.
+
+Applications that have a multi tenancy model, will supply an array of configs to the integration function [`altitudeMiddleware`](/packages/astro-integration/#invoke-the-integration). It is recommended that each tenants config is in their own respective file and exported from a single file to keep the configs tidy, sectioned and consistent.
+
+```javascript
+// /config/index.js
+import siteOne from "./siteOne";
+import siteTwo from "./siteTwo";
+import siteThree from "./siteThree";
+
+export default [siteOne, siteTwo, siteThree];
+```
+
+#### Multi Tenancy Config
+
+As well as defining tenant specific endpoints and KV keys, the config file allows application owners to extend any site specific values and expose these at runtime. One benefit that the integration allows is the ability to unlock tenant specific environment variables. Tenant specific secrets can be supplied to the build config. The integration exports an `env` function which can be imported and invoked inside of individual build configs. The `env` function takes in the **reference** of the environment variable as an argument not the value.
+
+```js
+//config/siteOne.js
+import { env } from '@thg-altitude/astro-integration'
+export default {
+  domains: {
+    default: "www.example.com",
+    variants: ["www.example.com"],
+  },
+  ... // exsiting site setup
+  blog: {
+    secret: env('EXAMPLE_SITE_BLOG_SECRET')
+  }
+};
+```
+
+The value of this environment variable can then be accessed by using the [altitude global context](/packages/astro-integration/#altitude-global-context) `altitude.runtime.config`.
+
+```javascript
+---
+const { altitude, runtime } = Astro.locals
+
+// runtime(Production) vs vite development server(Local development)
+const blogSecret = runtime ? runtime.env[altitude.runtime.config.blog.secret] : import.meta.env[altitude.runtime.config.blog.secret]
+---
+```
+
+### Tenant Switching
+
+When developing in a multi tenanted application, it may be desired that you are able to switch between tenants on the fly. For local development and DEV/UAT cloudflare environments this is easily achieved by adding a custom HTTP header to the request. The header to be used must be `x-altitude-instance` and the value will determine which tenant to switch to. This value should exist in that tenants config file, listed under the [`domains.variants`](/packages/astro-integration/#domains-options) array. Tenant switching will not be enabled on live domains.
+
+Applications that are using [localised domains](/guides/i18n/#localised-domains) will use the domain associated to that locale.

--- a/src/content/docs/astro-integration/guides/multitenancy.md
+++ b/src/content/docs/astro-integration/guides/multitenancy.md
@@ -6,6 +6,7 @@ description: Serve multiple brands from a single Altitude site.
 Multi-tenancy is a pattern in which multiple brands may be served from the same codebase. It can be used to quickly onboard a new brand, or 'tenant', via a new configuration, as a fast route to scale.
 
 ---
+# Multi-tenancy
 
 ## Custom Domains
 

--- a/src/content/docs/astro-integration/index.md
+++ b/src/content/docs/astro-integration/index.md
@@ -75,7 +75,7 @@ commerce: {
 **Type:** `Object` \
 **Required: False**
 
-This block allows headers to be added to a request to the [commerce endpoint](/packages/astro-integration/#altitude-commerce-endpoint) on the server side. The name of the header is the key, and the value an object with a type key of "env"|"request" to specify if the value should be taken from environment variables, or from another request header. This is useful for sensitive headers that should not be accessible in the browser, and retaining the value of a header that may get overwritten or masked as it passes through proxies, e.g. client_ip.
+This block allows headers to be added to a request to the [commerce endpoint](#altitude-commerce-endpoint) on the server side. The name of the header is the key, and the value an object with a type key of "env"|"request" to specify if the value should be taken from environment variables, or from another request header. This is useful for sensitive headers that should not be accessible in the browser, and retaining the value of a header that may get overwritten or masked as it passes through proxies, e.g. client_ip.
 
 ```javascript
 commerce: {
@@ -105,7 +105,7 @@ x-example-new-header : request.headers.get('old-header-name')
 **Type:** `Array[]` \
 **Required: True**
 
-An array of KV options can be supplied. Below are the options that should be supplied per entry. See the [Edge KV](/guides/edge-kv/#astro-integration) guide for more details.
+An array of KV options can be supplied. Below are the options that should be supplied per entry. See the [Edge KV](./guides/edge-kv) guide for more details.
 
 This field is required even if all locale specific configs have their own KV entries. So use this section either for a sensible set of default values or leave it as an empty array if you are sure that all locales have correct KV configs.
 
@@ -132,7 +132,7 @@ The key to be retrieved in your Cloudflare KV store.
 **Type:** `String` \
 **Required: True**
 
-This value will be used to attach the contents of the KV key to a specified namespace on the altitude global context e.g. `altitude.runtime.kv.<namespace>`. More details on the altitude namespace can be found [here](/packages/astro-integration/#altitude-global-context)
+This value will be used to attach the contents of the KV key to a specified namespace on the altitude global context e.g. `altitude.runtime.kv.<namespace>`. More details on the altitude namespace can be found [here](#altitude-global-context)
 
 ### \<Object>.local
 

--- a/src/content/docs/astro-integration/index.md
+++ b/src/content/docs/astro-integration/index.md
@@ -551,7 +551,7 @@ Currently this endpoint uses 4 values in the body:
 
 Application currently only applies to the use of the Multi-Tenanted Account option, with a value of 'account'.opaqueCookieDomain allows access the correct domains when setting response headers.
 
-Variables handles any input needed by the Horizon query. The horizonApq setting allows enabling [persisted queries](/packages/astro-integration/#options.apqEnabled)
+Variables handles any input needed by the Horizon query. The horizonApq setting allows enabling [persisted queries](#commerce-api)
 
 ```
 const variables {...}

--- a/src/content/docs/astro-integration/index.md
+++ b/src/content/docs/astro-integration/index.md
@@ -46,7 +46,7 @@ The default domain of a site excluding protocol. This value is used in conjuctio
 **Type:** `Array[]` \
 **Required: True**
 
-Contains all additional domains associated with a site inclusive of the default. This is the value the integration uses to map to this config. The header `x-altitude-instance` can be used to switch between different configs for local development, see the [multi tenancy](/guides/multi-tenancy/#tenant-switching) guide for further information on how this works.
+Contains all additional domains associated with a site inclusive of the default. This is the value the integration uses to map to this config. The header `x-altitude-instance` can be used to switch between different configs for local development, see the [multi tenancy](/docs/astro-integration/guides/multitenancy/#tenant-switching) guide for further information on how this works.
 
 ```javascript
 domains: {

--- a/src/content/docs/astro-integration/index.md
+++ b/src/content/docs/astro-integration/index.md
@@ -508,7 +508,7 @@ The Astro route injection uses pattern matching to direct requests to the endpoi
 
 ### Configuring the endpoint
 
-Firstly, there is a requirement to add `api` to the tenant build config `exclusionList` to avoid localisation rewrites, which would result in the route 404ing. More information on this can be found in the documentation: https://docs.alliance.thgaltitude.com/guides/i18n/#i18nexclusionlist
+Firstly, there is a requirement to add `api` to the tenant build config `exclusionList` to avoid localisation rewrites, which would result in the route 404ing. More information on this can be found in the [documentation](./guides/i18n/#i18nexclusionlist)
 
 ```js
 // tenant config obj
@@ -574,7 +574,7 @@ The integration will provide additional information about the config resolvement
 
 ### altitude.runtime.config
 
-The build config object the integration has resolved to. For applications using the integrations [localisation](/guides/i18n/#astro-integration) solution this will be the locale specific config.
+The build config object the integration has resolved to. For applications using the integration's [localisation](./guides/i18n) solution this will be the locale specific config.
 
 ### altitude.runtime.kv.\<namespace>
 
@@ -582,7 +582,7 @@ The value of [KV](/packages/astro-integration/#kv) retrieved using the key provi
 
 <h2 id="internationalisation">Internationalisation</h2>
 
-These keys will be provided on the altitude namespace for applications that are using the built in i18n solution. Further information can be found [here](/guides/i18n/#astro-integration)
+These keys will be provided on the altitude namespace for applications that are using the built in i18n solution. Further information can be found [here](./guides/i18n)
 
 ### altitude.locale
 

--- a/src/content/docs/astro-integration/index.md
+++ b/src/content/docs/astro-integration/index.md
@@ -39,14 +39,14 @@ export default {
 **Type**: `String` \
 **Required: True**
 
-The default domain of a site excluding protocol. This value is used in conjuction with i18n, see [internationalisation](/guides/i18n/#astro-integration) for further information on this value.
+The default domain of a site excluding protocol. This value is used in conjuction with i18n, see [internationalisation](/docs/astro-integration/guides/i18n) for further information on this value.
 
 ### domains.variants
 
 **Type:** `Array[]` \
 **Required: True**
 
-Contains all additional domains associated with a site inclusive of the default. This is the value the integration uses to map to this config. The header `x-altitude-instance` can be used to switch between different configs for local development, see the [multi tenancy](/docs/astro-integration/guides/multitenancy/#tenant-switching) guide for further information on how this works.
+Contains all additional domains associated with a site inclusive of the default. This is the value the integration uses to map to this config. The header `x-altitude-instance` can be used to switch between different configs for local development, see the [multi tenancy](/docs/astro-integration/guides/multitenancy) guide for further information on how this works.
 
 ```javascript
 domains: {
@@ -62,7 +62,7 @@ domains: {
 **Type:** `String` \
 **Required: False**
 
-The commerce api endpoint the specified site uses. This value will be used with the [commerce api](/packages/astro-integration/#commerce-api) method and must be provided if your application intends to use this method.
+The commerce api endpoint the specified site uses. This value will be used with the [commerce api](#commerce-api) method and must be provided if your application intends to use this method.
 
 ```javascript
 commerce: {

--- a/src/content/docs/astro-integration/index.md
+++ b/src/content/docs/astro-integration/index.md
@@ -46,7 +46,7 @@ The default domain of a site excluding protocol. This value is used in conjuctio
 **Type:** `Array[]` \
 **Required: True**
 
-Contains all additional domains associated with a site inclusive of the default. This is the value the integration uses to map to this config. The header `x-altitude-instance` can be used to switch between different configs for local development, see the [multi tenancy](./guides/multitenancy) guide for further information on how this works.
+Contains all additional domains associated with a site inclusive of the default. This is the value the integration uses to map to this config. The header `x-altitude-instance` can be used to switch between different configs for local development, see the [multi tenancy](/docs/astro-integration/guides/multitenancy) guide for further information on how this works.
 
 ```javascript
 domains: {
@@ -105,7 +105,7 @@ x-example-new-header : request.headers.get('old-header-name')
 **Type:** `Array[]` \
 **Required: True**
 
-An array of KV options can be supplied. Below are the options that should be supplied per entry. See the [Edge KV](./guides/edge-kv) guide for more details.
+An array of KV options can be supplied. Below are the options that should be supplied per entry. See the [Edge KV](/docs/astro-integration/guides/edge-kv) guide for more details.
 
 This field is required even if all locale specific configs have their own KV entries. So use this section either for a sensible set of default values or leave it as an empty array if you are sure that all locales have correct KV configs.
 
@@ -158,7 +158,7 @@ kv: [
 
 ## Custom
 
-Custom keys can also be supplied to the build config, such as environment variables. These values will not affect the configuration of the integration but will be provided on the [altitude global context](/packages/astro-integration/#altitude-global-context) at runtime. This is useful for multi tenancy when values need to change based on each tenants config. Further information can be found in the [multi tenancy guide](./guides/multitenancy)
+Custom keys can also be supplied to the build config, such as environment variables. These values will not affect the configuration of the integration but will be provided on the [altitude global context](#altitude-global-context) at runtime. This is useful for multi tenancy when values need to change based on each tenants config. Further information can be found in the [multi tenancy guide](/docs/astro-integration/guides/multitenancy)
 
 ## Invoking the integration
 
@@ -247,7 +247,7 @@ The keys used for copy on site can be exposed using headers. This will allow the
 
 ### Commerce API
 
-The integration provides out the box commerce api fetching on the server exposing the method as `altitude.commerce.api`. The method enables applications to configure the operation, variables and headers to retrieve commerce data for a given site or tenant. The endpoint the method will use for these calls will be the `commerce.endpoint` supplied in an application or tenants [build config](/packages/astro-integration/#configuration).
+The integration provides out the box commerce api fetching on the server exposing the method as `altitude.commerce.api`. The method enables applications to configure the operation, variables and headers to retrieve commerce data for a given site or tenant. The endpoint the method will use for these calls will be the `commerce.endpoint` supplied in an application or tenants [build config](#configuration).
 
 #### operationFields.operation
 
@@ -508,7 +508,7 @@ The Astro route injection uses pattern matching to direct requests to the endpoi
 
 ### Configuring the endpoint
 
-Firstly, there is a requirement to add `api` to the tenant build config `exclusionList` to avoid localisation rewrites, which would result in the route 404ing. More information on this can be found in the [documentation](./guides/i18n/#i18nexclusionlist)
+Firstly, there is a requirement to add `api` to the tenant build config `exclusionList` to avoid localisation rewrites, which would result in the route 404ing. More information on this can be found in the [documentation](/docs/astro-integration/guides/i18n/#i18nexclusionlist)
 
 ```js
 // tenant config obj
@@ -574,15 +574,15 @@ The integration will provide additional information about the config resolvement
 
 ### altitude.runtime.config
 
-The build config object the integration has resolved to. For applications using the integration's [localisation](./guides/i18n) solution this will be the locale specific config.
+The build config object the integration has resolved to. For applications using the integration's [localisation](/docs/astro-integration/guides/i18n) solution this will be the locale specific config.
 
 ### altitude.runtime.kv.\<namespace>
 
-The value of [KV](/packages/astro-integration/#kv) retrieved using the key provided. This will be attached using the namespace value provided in the KV for the key retrieved.
+The value of [KV](#kv) retrieved using the key provided. This will be attached using the namespace value provided in the KV for the key retrieved.
 
 <h2 id="internationalisation">Internationalisation</h2>
 
-These keys will be provided on the altitude namespace for applications that are using the built in i18n solution. Further information can be found [here](./guides/i18n)
+These keys will be provided on the altitude namespace for applications that are using the built in i18n solution. Further information can be found [here](/docs/astro-integration/guides/i18n)
 
 ### altitude.locale
 

--- a/src/content/docs/astro-integration/index.md
+++ b/src/content/docs/astro-integration/index.md
@@ -46,7 +46,7 @@ The default domain of a site excluding protocol. This value is used in conjuctio
 **Type:** `Array[]` \
 **Required: True**
 
-Contains all additional domains associated with a site inclusive of the default. This is the value the integration uses to map to this config. The header `x-altitude-instance` can be used to switch between different configs for local development, see the [multi tenancy](/docs/astro-integration/guides/multitenancy) guide for further information on how this works.
+Contains all additional domains associated with a site inclusive of the default. This is the value the integration uses to map to this config. The header `x-altitude-instance` can be used to switch between different configs for local development, see the [multi tenancy](./guides/multitenancy) guide for further information on how this works.
 
 ```javascript
 domains: {
@@ -158,7 +158,7 @@ kv: [
 
 ## Custom
 
-Custom keys can also be supplied to the build config, such as environment variables. These values will not affect the configuration of the integration but will be provided on the [altitude global context](/packages/astro-integration/#altitude-global-context) at runtime. This is useful for multi tenancy when values need to change based on each tenants config. Further information can be found in the [multi tenancy guide](/guides/multi-tenancy/#multi-tenancy-config)
+Custom keys can also be supplied to the build config, such as environment variables. These values will not affect the configuration of the integration but will be provided on the [altitude global context](/packages/astro-integration/#altitude-global-context) at runtime. This is useful for multi tenancy when values need to change based on each tenants config. Further information can be found in the [multi tenancy guide](./guides/multitenancy)
 
 ## Invoking the integration
 


### PR DESCRIPTION
- fixed links /astro-integration 
- migrated three guides which were linked from /astro-integration (copied over from old docs site at https://github.com/THG-AltitudeSiteBuilds/commerce-docs)

links fixed:

![image](https://github.com/user-attachments/assets/38bbd68c-2c56-4898-850a-64899562f7ed)

![image](https://github.com/user-attachments/assets/aa1fa3ca-6cf9-4327-a1f0-f9005155939c)

... and a few more on that page

BEFORE: https://thgaltitude.com/docs/astro-integration
AFTER: https://df9f75e1.thgaltitude.com/docs/astro-integration
